### PR TITLE
duplicate slide method via relationships

### DIFF
--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -298,19 +298,18 @@ class Slides(ParentedElementProxy):
         """
         Return a newly added slide that inherits layout from *slide_layout*.
         """
-        def add_existing_slide(presentation, existing_slide):
+        # this generates a repair error through, due to duplicates, such as layouts and themes
+        def add_existing_slide(slides, target_slide):
             """
             Return an (rId, slide) of an already created slide
             """
             from pptx.opc.constants import RELATIONSHIP_TYPE as RT
-            rId = presentation.part.relate_to(existing_slide.part, RT.SLIDE)
-            return rId, existing_slide.part.slide
+            rId = slides.part.relate_to(target_slide.part, RT.SLIDE)
+            return rId, target_slide.part.slide
 
         if slide:
-            print("printing shapes")
-            rId, slide = add_existing_slide(self.presentation, slide)
+            rId, slide = add_existing_slide(self, slide)
             self._sldIdLst.add_sldId(rId)
-            print("done adding slide")
             return slide
         return None
 

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -4,6 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import copy
+
 from pptx.dml.fill import FillFormat
 from pptx.enum.shapes import PP_PLACEHOLDER
 from pptx.shapes.shapetree import (
@@ -16,6 +18,8 @@ from pptx.shapes.shapetree import (
     SlidePlaceholders,
     SlideShapes,
 )
+
+from pptx.parts.chart import ChartPart, EmbeddedXlsxPart
 from pptx.shared import ElementProxy, ParentedElementProxy, PartElementProxy
 from pptx.util import lazyproperty
 
@@ -293,6 +297,39 @@ class Slides(ParentedElementProxy):
         slide.shapes.clone_layout_placeholders(slide_layout)
         self._sldIdLst.add_sldId(rId)
         return slide
+
+    def duplicate_slide(self, target_slide):
+        """Duplicate the slide with the given index in pres.
+        Adds slide to the end of the presentation"""
+        source = target_slide
+        new_slide_layout = target_slide.slide_layout
+
+        dest = self.add_slide(new_slide_layout)
+
+        for shape in source.shapes:
+            newel = copy.deepcopy(shape.element)
+            dest.shapes._spTree.insert_element_before(newel, 'p:extLst')
+
+        for key, value in source.part.rels.items():
+            # Make sure we don't copy a notesSlide relation as that won't exist
+            if "notesSlide" not in value.reltype:
+                target = value._target
+                # if the relationship was a chart, we need to duplicate the embedded chart part and xlsx
+                if "chart" in value.reltype:
+                    partname = target.package.next_partname(
+                        ChartPart.partname_template)
+                    xlsx_blob = target.chart_workbook.xlsx_part.blob
+                    target = ChartPart(partname, target.content_type,
+                                       copy.deepcopy(target._element), package=target.package)
+
+                    target.chart_workbook.xlsx_part = EmbeddedXlsxPart.new(
+                        xlsx_blob, target.package)
+
+                dest.part.rels.add_relationship(value.reltype,
+                                                target,
+                                                value.rId)
+
+        return dest
 
     def get(self, slide_id, default=None):
         """

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -307,9 +307,36 @@ class Slides(ParentedElementProxy):
             rId = slides.part.relate_to(target_slide.part, RT.SLIDE)
             return rId, target_slide.part.slide
 
+        def check_existing_rels(slides):
+            """Returns a list of slides relationships to compare before/after duplicating"""
+            return slides.part.rels
+
+        def check_slide_rel_parts(slide):
+            return slide.part.rels.related_parts
+
+        # print("slide parts")
+        # print(check_slide_rel_parts(slide))
+        # for rId in check_slide_rel_parts(slide):
+        #     print(rId)
+        #     print(type(slide.part.target_ref(rId)))
+        #     print(slide.part.target_ref(rId))
+        #
+        # print("initial rels")
+        # print(self.part.package)
+        # print(check_existing_rels(self))
+        print("MEDIA PARTS")
+        print(self.part.package._media_parts)
+        print(dir(self.part.package._media_parts))
+        for media in self.part.package._media_parts:
+            print(media)
+        print("IMAGE PARTS")
+        print(self.part.package._image_parts)
+
         if slide:
             rId, slide = add_existing_slide(self, slide)
             self._sldIdLst.add_sldId(rId)
+            print("after rels")
+            print(check_existing_rels(self))
             return slide
         return None
 

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -501,15 +501,15 @@ class DescribeSlides(object):
         assert slides._sldIdLst.xml == expected_xml
         assert slide is slide_
 
-    def it_can_duplicate_a_slide(self, add_fixture):
-        from pptx.slide import Slide
-        slides = add_fixture[0]
-        new_slide = Slide(None, slides.part)
-        # Slide is a magicmock, atm
+    def it_can_duplicate_a_slide(self, slide_fixture):
+        from pptx import Presentation
+        prs = Presentation()
+        prs.slides.add_slide(prs.slide_layouts[1])
+        slides = slide_fixture[0].slides
 
-        duplicated_slide = slides.duplicate_slide(new_slide)
+        duplicated_slide = slides.duplicate_slide(prs.slides[0])
 
-        assert duplicated_slide is new_slide
+        assert duplicated_slide is prs.slides[0]
 
     def it_finds_a_slide_by_slide_id(self, get_fixture):
         slides, slide_id, default, prs_part_, expected_value = get_fixture
@@ -533,6 +533,17 @@ class DescribeSlides(object):
             clone_layout_placeholders_,
             expected_xml,
             slide_,
+        )
+
+    @pytest.fixture
+    def slide_fixture(self):
+        from pptx import Presentation
+        prs = Presentation()
+        prs.slides._element = element("p:sldIdLst/p:sldId{r:id=rId1}")
+        slides = Slides(element("p:sldIdLst/p:sldId{r:id=rId1}"), None)
+        return (
+            prs,
+            slides,
         )
 
     @pytest.fixture(params=[True, False])

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -501,6 +501,16 @@ class DescribeSlides(object):
         assert slides._sldIdLst.xml == expected_xml
         assert slide is slide_
 
+    def it_can_duplicate_a_slide(self, add_fixture):
+        from pptx.slide import Slide
+        slides = add_fixture[0]
+        new_slide = Slide(None, slides.part)
+        # Slide is a magicmock, atm
+
+        duplicated_slide = slides.duplicate_slide(new_slide)
+
+        assert duplicated_slide is new_slide
+
     def it_finds_a_slide_by_slide_id(self, get_fixture):
         slides, slide_id, default, prs_part_, expected_value = get_fixture
         slide = slides.get(slide_id, default)


### PR DESCRIPTION
original branch has no support for copying in a `Slide` object into a presentation. It only had support for adding a new empty slide.

This method utilizes taking the slide and creating the relationships necessary to embed it in the presentation. It will carry over all the contents of that slide (to my knowledge)

Note that it creates a repair message when opening the presentation due to the duplication of layout names, etc. 

The alternative method is using deepcopy to copy all the components one by one, which also leaves the textboxes of a new layout on the slide, since it creates a new slide then copies the contents. As of testing today, both methods generate a repair popup in pptx