### PR TITLE
duplicate slide via deepcopy method + utility functions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://travis-ci.org/scanny/python-pptx.svg?branch=master
-   :target: https://travis-ci.org/scanny/python-pptx
+.. image:: https://travis-ci.com/mediapredict/python-pptx.svg?branch=master
+   :target: https://travis-ci.com/mediapredict/python-pptx
 
 *python-pptx* is a Python library for creating and updating PowerPoint (.pptx)
 files.

--- a/docs/user/slides.rst
+++ b/docs/user/slides.rst
@@ -86,6 +86,23 @@ A few things to note:
   a feature request for that I expect I'll add an ``insert_slide(idx, ...)``
   method.
 
+Duplicating a slide
+--------------
+
+Let's use the Title and Content slide layout; a lot of slides do::
+
+    SLD_LAYOUT_TITLE_AND_CONTENT = 1
+
+    prs = Presentation()
+    slide = prs.slides[0]
+    slide = prs.slides.duplicate_slide(slide)
+
+A few things to note:
+
+* Duplicating a slide will copy the layout from the slide chosen. All the content in the source slide
+  will be deepcopied. Note that this may result in a repair popup when opening the pptx file due to duplicate names
+  of parts like ``slide_layout, themes, etc.``
+
 
 Doing other things with slides
 ------------------------------

--- a/docs/user/text.rst
+++ b/docs/user/text.rst
@@ -169,6 +169,7 @@ the theme color Accent 1.
     font.italic = None  # cause value to be inherited from theme
     font.color.theme_color = MSO_THEME_COLOR.ACCENT_1
     font.superscript = True # sets superscript (baseline 30000)
+    font.subscript = True # sets subscript (baseline -25000), removes superscript
 
 If you prefer, you can set the font color to an absolute RGB value. Note that
 this will not change color when the theme is changed::

--- a/docs/user/text.rst
+++ b/docs/user/text.rst
@@ -168,6 +168,7 @@ the theme color Accent 1.
     font.bold = True
     font.italic = None  # cause value to be inherited from theme
     font.color.theme_color = MSO_THEME_COLOR.ACCENT_1
+    font.superscript = True # sets superscript (baseline 30000)
 
 If you prefer, you can set the font color to an absolute RGB value. Note that
 this will not change color when the theme is changed::

--- a/pptx/oxml/text.py
+++ b/pptx/oxml/text.py
@@ -27,6 +27,7 @@ from pptx.oxml.simpletypes import (
     ST_TextSpacingPoint,
     ST_TextTypeface,
     ST_TextWrappingType,
+    BaseIntType,
     XsdBoolean,
 )
 from pptx.oxml.xmlchemy import (
@@ -305,6 +306,7 @@ class CT_TextCharacterProperties(BaseOxmlElement):
     sz = OptionalAttribute("sz", ST_TextFontSize)
     b = OptionalAttribute("b", XsdBoolean)
     i = OptionalAttribute("i", XsdBoolean)
+    baseline = OptionalAttribute("baseline", BaseIntType)
     u = OptionalAttribute("u", MSO_TEXT_UNDERLINE_TYPE)
 
     def _new_gradFill(self):

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -508,7 +508,6 @@ class SlideLayouts(ParentedElementProxy):
         generated_rID = slide_layout.slide_master.part.rels._next_rId
         rId = slide_layout.slide_master.part.rels.add_relationship(
             RT.SLIDE_LAYOUT, slide_layout.part, generated_rID).rId
-        slide_layout.slide_master.part.drop_rel(rId)
 
         # Fills new sldlstId with the newly generated rId, then adds to sldLayoutIdLst
         new_sld_id.rID = rId

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -300,7 +300,7 @@ class Slides(ParentedElementProxy):
         self._sldIdLst.add_sldId(rId)
         return slide
 
-    def duplicate_slide(self, source_slide):
+    def duplicate_slide(self, source_slide, slide_layout=None):
         """Duplicate the slide with the given index in pres.
         Adds slide to the end of the presentation, uses old slide's layout"""
         if not source_slide:
@@ -308,8 +308,15 @@ class Slides(ParentedElementProxy):
 
         from pptx.parts.slide import SlideLayoutPart
 
-        #dest = self.add_slide(source_slide.slide_layout)
-        dest = self.add_slide(SlideLayout(CT_SlideLayout, SlideLayoutPart("blanklayout", "xml", CT_SlideLayout)))
+        if not slide_layout:
+            new_layout = None
+            for layout in self.part._presentation.slide_layouts:
+                if layout.name.lower() == "blank":
+                    new_layout = layout
+            if new_layout:
+                dest = self.add_slide(new_layout)
+            else:
+                dest = self.add_slide(SlideLayout(CT_SlideLayout, SlideLayoutPart("blanklayout", "xml", CT_SlideLayout)))
 
         for shape in source_slide.shapes:
             newel = copy.deepcopy(shape.element)
@@ -496,11 +503,11 @@ class SlideLayouts(ParentedElementProxy):
         self._sldLayoutIdLst.sldLayoutId_lst.append(slide_layout)
 
         # Get last slide_layoutID's id attribute to increment
-        last_sldLayoutId = self._sldLayoutIdLst[len(self._sldLayoutIdLst)].attrib["id"]
+        last_sldLayoutId = self._sldLayoutIdLst[len(self._sldLayoutIdLst) - 1].attrib["id"]
 
         # Build a new sldlstId, need to create an rID attribute though.
         new_sld_id = self._sldLayoutIdLst._new_sldLayoutId()
-        new_sld_id["id"] = last_sldLayoutId
+        new_sld_id.id = last_sldLayoutId
 
         from pptx.opc.constants import RELATIONSHIP_TYPE as RT
 

--- a/pptx/slide.py
+++ b/pptx/slide.py
@@ -298,21 +298,19 @@ class Slides(ParentedElementProxy):
         self._sldIdLst.add_sldId(rId)
         return slide
 
-    def duplicate_slide(self, slide):
+    def duplicate_slide(self, source_slide):
         """Duplicate the slide with the given index in pres.
-        Adds slide to the end of the presentation"""
-        if not slide:
+        Adds slide to the end of the presentation, uses old slide's layout"""
+        if not source_slide:
             return
-        source = slide
-        blank_slide_layout = source.slide_layout
 
-        dest = self.add_slide(blank_slide_layout)
+        dest = self.add_slide(source_slide.slide_layout)
 
-        for shape in source.shapes:
+        for shape in source_slide.shapes:
             newel = copy.deepcopy(shape.element)
             dest.shapes._spTree.insert_element_before(newel, 'p:extLst')
 
-        for key, value in source.part.rels.items():
+        for key, value in source_slide.part.rels.items():
             # Make sure we don't copy a notesSlide relation as that won't exist
             if "notesSlide" not in value.reltype:
                 target = value._target

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -341,11 +341,29 @@ class Font(object):
 
     @property
     def superscript(self):
-        return self._rPr.baseline
+        # baseline of 30000 means superscript
+        if self._rPr.baseline == 30000:
+            return True
+        return False
 
     @superscript.setter
     def superscript(self, value):
-        self._rPr.baseline = value
+        self._rPr.baseline = 0
+        if value:
+            self._rPr.baseline = 30000
+
+    @property
+    def subscript(self):
+        # baseline of -25000 means superscript
+        if self._rPr.baseline == -25000:
+            return True
+        return False
+
+    @subscript.setter
+    def subscript(self, value):
+        self._rPr.baseline = 0
+        if value:
+            self._rPr.baseline = -25000
 
     @property
     def language_id(self):

--- a/pptx/text/text.py
+++ b/pptx/text/text.py
@@ -340,6 +340,14 @@ class Font(object):
         self._rPr.i = value
 
     @property
+    def superscript(self):
+        return self._rPr.baseline
+
+    @superscript.setter
+    def superscript(self, value):
+        self._rPr.baseline = value
+
+    @property
     def language_id(self):
         """
         Get or set the language id of this |Font| instance. The language id

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -501,6 +501,16 @@ class DescribeSlides(object):
         assert slides._sldIdLst.xml == expected_xml
         assert slide is slide_
 
+    def it_can_duplicate_a_slide(self, slide_fixture):
+        from pptx import Presentation
+        prs = Presentation()
+        prs.slides.add_slide(prs.slide_layouts[1])
+        slides = slide_fixture[0].slides
+
+        duplicated_slide = slides.duplicate_slide(prs.slides[0])
+
+        assert duplicated_slide is prs.slides[0]
+
     def it_finds_a_slide_by_slide_id(self, get_fixture):
         slides, slide_id, default, prs_part_, expected_value = get_fixture
         slide = slides.get(slide_id, default)
@@ -523,6 +533,17 @@ class DescribeSlides(object):
             clone_layout_placeholders_,
             expected_xml,
             slide_,
+        )
+
+    @pytest.fixture
+    def slide_fixture(self):
+        from pptx import Presentation
+        prs = Presentation()
+        prs.slides._element = element("p:sldIdLst/p:sldId{r:id=rId1}")
+        slides = Slides(element("p:sldIdLst/p:sldId{r:id=rId1}"), None)
+        return (
+            prs,
+            slides,
         )
 
     @pytest.fixture(params=[True, False])

--- a/tests/test_slide.py
+++ b/tests/test_slide.py
@@ -509,7 +509,11 @@ class DescribeSlides(object):
 
         duplicated_slide = slides.duplicate_slide(prs.slides[0])
 
-        assert duplicated_slide is prs.slides[0]
+        duplicated_shapes = []
+        for shape in duplicated_slide.shapes:
+            duplicated_shapes.append(shape.name)
+        for shape in prs.slides[0].shapes:
+            assert shape.name in duplicated_shapes
 
     def it_finds_a_slide_by_slide_id(self, get_fixture):
         slides, slide_id, default, prs_part_, expected_value = get_fixture


### PR DESCRIPTION
Uses deepcopy method, will result in a repair popup, but works with any slide at the moment over relationship method.

Can take a slide object from anywhere and duplicate it into the powerpoint